### PR TITLE
Reduce health check interval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ WORKDIR /app
 RUN apk --no-cache add curl krb5 bash
 
 # Add health check
-HEALTHCHECK --interval=5m --timeout=3s \
+HEALTHCHECK --interval=30s --timeout=3s \
     CMD ./healthcheck.sh
 
 # Expose default HTTP port


### PR DESCRIPTION
Docker Swarm services become available when the first health
check succeeds. This change reduces the health check interval
so the service will be available sooner.