### PR TITLE
Added a zoonavigator-api user to Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# vim
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,21 @@ WORKDIR /app
 # Install dependencies
 RUN apk --no-cache add curl krb5 bash
 
+# Create non-root user
+RUN addgroup -g 1000 zoonavigator-api && \
+    adduser -D -u 1000 zoonavigator-api -G zoonavigator-api
+
 # Add health check
 HEALTHCHECK --interval=30s --timeout=3s \
     CMD ./healthcheck.sh
 
 # Expose default HTTP port
 EXPOSE 9000
+
+# Ensure that our user can access /app
+RUN chown -R zoonavigator-api:zoonavigator-api /app
+
+# Cause our command to be executed as our user
+USER zoonavigator-api:zoonavigator-api
 
 CMD ["./run.sh"]


### PR DESCRIPTION
This pull request addresses issues raised in elkozmon/zoonavigator#36.
What it does:
* Causes zoonavigator-api to run as a non-root user inside a Docker container

Why is it needed:
* Some security environments only allow Docker images that run as non-root and there is no need for zoo-navigator to run as root.

Potential risks:
* None - this should be a completely transparent change to end users