### PR TITLE
Fix Curator Deps for Zk 3.4.X & CI Build

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,8 @@ import sbt._
 object Dependencies {
   private[Dependencies] object V {
     val cats      = "2.2.0"
-    val curator   = "5.3.0"
+    val curator   = "4.2.0"
+    val curatorTest = "2.12.0"
     val macwire   = "2.3.3"
     val zookeeper = "3.4.11"
     val log4j     = "2.17.2"
@@ -24,7 +25,8 @@ object Dependencies {
   val macwireProxy  = "com.softwaremill.macwire" %% "proxy"  % V.macwire
   val macwireMacros = "com.softwaremill.macwire" %% "macros" % V.macwire % Provided
 
-  val curatorTest = "org.apache.curator" % "curator-test" % V.curator % Test
+  val curatorTest =
+    "org.apache.curator" % "curator-test" % V.curatorTest % Test exclude ("org.apache.zookeeper", "zookeeper")
   val curatorFramework =
     "org.apache.curator" % "curator-framework" % V.curator exclude ("org.apache.zookeeper", "zookeeper")
 


### PR DESCRIPTION
Hey @elkozmon !

Looks like Curator was previously bumped to 5.3.0 but the Zookeeper dep is still pinned at 3.14.11, a version which is only supported by curator up to 4.2.0... See https://curator.apache.org/docs/zk-compatibility-34/

Since the last stable release (1.1.2) was built with curator 4.0.0 and Zk 3.14.11, I suggest we fix the CI/build with this PR first, and look to bump zookeeper/curator in a next version/PR to avoid any regression. Let me know what you think!

Could you also take a look at [my other PR on zoonavigator-web](https://github.com/elkozmon/zoonavigator-web/pull/49) which is fixing the build problem for that component.